### PR TITLE
Update to discord.js@11.6.4 and using guild.fetchMember (fetch by id …

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "connect-nedb-session": "^0.0.3",
-    "discord.js": "^11.5.1",
+    "discord.js": "^11.6.4",
     "express": "^4.17.1",
     "express-handlebars": "^3.1.0",
     "express-session": "^1.17.0",

--- a/web/epgp_guild.js
+++ b/web/epgp_guild.js
@@ -58,9 +58,8 @@ module.exports.viewguild = (req, res) => {
   db.findOne({ id: req.params.guildid }, (err, guildDB) => {
     if (err) logger.error(err);
 
-    guild.fetchMembers(req.session.discord_user.username)
-      .then(guild => {
-        const member = guild.members.get(req.session.discord_user.id);
+    guild.fetchMember(req.session.discord_user.id, false)
+      .then(member => {
         const epgpManager = member.roles.find(r => r.name === guildDB.epgpManager)
         req.session.epgpManager = Boolean(epgpManager);
         logger.info('EP/GP User: ' + member.user.username + ' has EPGP Manager role: ' + guildDB.epgpManager + '=' + req.session.epgpManager);


### PR DESCRIPTION
…instead of name)

With discord.js@11.6.4 it is possible to fetchMember by id instead of by name.
With discord.js@11.5.1 I changed my username and due to some sort of caching, either discord server or bot client, the user could not be found by name. When I set my discord user name back it could be found again.