### PR TITLE
Allow setting epgpManager when property is not defined in database.

### DIFF
--- a/bot/message.js
+++ b/bot/message.js
@@ -49,7 +49,7 @@ const handleMessage = (guild, bot, message, args, command) => {
   if (!(memberAdmin && command === 'config') && bot.disabled) {
     // Silently return unless an admin is processing configuration
     return;
-  } else if (guild.epgpManager && command === 'manager') {
+  } else if (startsWithIgnoreCase(command, 'manager')) {
     if (!memberAdmin) {
       reply.push('Only server administrators can update the bot configuration');
     } else if (args.length === 0) {


### PR DESCRIPTION
On the production server all existing guilds do not have the database property epgpManager defined.
In the message hande a test is performed if the epgpManager exists. This result it not being able to set/get the epgpManager value.

The only option is to remove and add the guild again which is not nice.